### PR TITLE
Fix multidimensional array check #39

### DIFF
--- a/src/Core/DOMParser.php
+++ b/src/Core/DOMParser.php
@@ -122,6 +122,17 @@ class DOMParser
         return $this->mergeSimilarNodes($nodes);
     }
 
+    private function isMultidimensionalArray($array)
+    {
+        foreach ($array as $value) {
+            if (is_array($value)) {
+                return true;
+            }
+        }
+        
+        return false;
+    }
+
     private function mergeSimilarNodes($nodes)
     {
         $result = [];
@@ -131,10 +142,7 @@ class DOMParser
          */
         array_reduce($nodes, function ($carry, $node) use (&$result) {
             // Ignore multidimensional arrays
-            if (
-                count($node) !== count($node, COUNT_RECURSIVE)
-                || count($carry) !== count($carry, COUNT_RECURSIVE)
-            ) {
+            if ($this->isMultidimensionalArray($node) || $this->isMultidimensionalArray($carry)) {
                 $result[] = $node;
 
                 return $node;

--- a/tests/DOMParser/EmptyNodesTest.php
+++ b/tests/DOMParser/EmptyNodesTest.php
@@ -1,0 +1,25 @@
+<?php
+
+use Tiptap\Editor;
+
+test('parsing must not fail on empty nodes', function () {
+    $html = '<p><img /></p><p><img /></p>';
+
+    $result = (new Editor)
+        ->setContent($html)
+        ->getDocument();
+
+    expect($result)->toEqual([
+        'type' => 'doc',
+        'content' => [
+            [
+                'type' => 'paragraph',
+                'content' => [],
+            ],
+            [
+                'type' => 'paragraph',
+                'content' => [],
+            ],
+        ],
+    ]);
+});


### PR DESCRIPTION
by @godismyjudge95

> This fixes https://github.com/ueberdosis/tiptap-php/issues/25

The issue is that the count method of checking if an array is multidimensional does not account for an edge case of a sub empty array:
https://3v4l.org/16rVK

This issue is discussed rather in depth here: https://stackoverflow.com/questions/145337/checking-if-array-is-multidimensional-or-not

Based off the testing done by the solution poster, this method of testing for a multidimensional array is the fastest while producing the correct output:

```
function is_multi2($a) {
    foreach ($a as $v) {
        if (is_array($v)) return true;
    }
    return false;
}
```
This PR adds a private method isMultidimensionalArray implementing that method.
I have tested this locally and it works properly, let me know if I need to create a test for it.